### PR TITLE
Refactor TestGenerator to use TestGenerationRequest dataclass - Full …

### DIFF
--- a/agents/test_generator.py
+++ b/agents/test_generator.py
@@ -3,13 +3,19 @@ from pydantic_ai import Agent
 from dotenv import load_dotenv
 import textwrap
 from . import utils
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
 class GenerationAttempt:
     code: str
     errors: str
+
+
+@dataclass(frozen=True)
+class TestGenerationRequest:
+    interface_str: str
+    prior_attempts: list[GenerationAttempt] = field(default_factory=list)
 
 
 class TestGenerator:
@@ -24,7 +30,7 @@ class TestGenerator:
                 'standard python `unittest` library.')
         )
 
-    def _make_initial_prompt(self, python_interface: str) -> str:
+    def _make_initial_prompt(self, interface_str: str) -> str:
         example_test = textwrap.dedent('''
             import unittest
             from my_interface import MyInterface
@@ -51,7 +57,7 @@ class TestGenerator:
             f'{utils.wrap_code_in_markdown(example_test)}'
             'Now generate a test suite in the same style, for testing the interface provided '
             'below. Make sure to cover edge cases, happy paths and error handling:\n\n'
-            f'{utils.wrap_code_in_markdown(python_interface)}'
+            f'{utils.wrap_code_in_markdown(interface_str)}'
         )
 
     def _make_improvement_prompt(
@@ -73,20 +79,18 @@ class TestGenerator:
         )
 
     def str_to_str(
-            self, python_interface: str, prior_attempts: list[GenerationAttempt] = []
+            self, request: TestGenerationRequest
     ) -> str:
         """Returns the test implementation code."""
-        if prior_attempts:
-            prompt = self._make_improvement_prompt(python_interface, prior_attempts)
+        if request.prior_attempts:
+            prompt = self._make_improvement_prompt(interface_str=request.interface_str, prior_attempts=request.prior_attempts)
         else:
-            prompt = self._make_initial_prompt(python_interface)
+            prompt = self._make_initial_prompt(interface_str=request.interface_str)
         result = asyncio.run(self._test_creator_agent.run(prompt))
         return utils.extract_code(result.data)
 
-    def str_to_file(
-            self, interface_str: str, output_path: str, prior_attempts: list[GenerationAttempt] = []
-    ) -> str:
-        test_str = self.str_to_str(interface_str, prior_attempts)
+    def str_to_file(self, request: TestGenerationRequest, output_path: str) -> str:
+        test_str = self.str_to_str(request)
         with open(output_path, 'w') as output_file:
             output_file.write(test_str)
         return test_str
@@ -115,4 +119,5 @@ if __name__ == "__main__":
                 pass
         ''')
 
-    print(TestGenerator().str_to_str(example_interface))
+    request = TestGenerationRequest(interface_str=example_interface)
+    print(TestGenerator().str_to_str(request))

--- a/demo.py
+++ b/demo.py
@@ -170,12 +170,13 @@ def main(example_name: str):
 
     with open(iface_path, 'w') as iface_file:
         iface_file.write(example.code)
-
+    
+    request = test_generator.TestGenerationRequest(interface_str=example.code)
     if compilation_error := try_compile_file(iface_path):
         print(f'Your interface file has errors: {compilation_error}')
         return
 
-    test_str = test_gen.str_to_file(example.code, test_path)
+    test_str = test_gen.str_to_file(request, test_path)
     impl_str = impl_gen.str_to_file(impl_generator.ImplGenerationRequest(example.code, test_str), impl_path)
     tests_pass, test_output = run_tests(project_dir)
 
@@ -202,7 +203,8 @@ def main(example_name: str):
 
         print('Could not make tests pass after 5 attempts, will regenerate tests instead')
         test_attempts.append(test_generator.GenerationAttempt(test_str, test_output))
-        test_str = test_gen.str_to_file(example.code, test_path, test_attempts)
+        request = test_generator.TestGenerationRequest(interface_str=example.code, prior_attempts=test_attempts)
+        test_str = test_gen.str_to_file(request, test_path)
         tests_pass, test_output = run_tests(project_dir)
         num_impl_rounds = max_impl_rounds
         num_test_rounds -= 1

--- a/start.py
+++ b/start.py
@@ -82,10 +82,12 @@ class ProjectEventHandler(FileSystemEventHandler):
             iface_str = iface_file.read()
 
         test_path = iface_path.replace('.py', '_test.py')
-        test_str = self._test_gen.str_to_file(iface_str, test_path)
+        request = test_generator.TestGenerationRequest(interface_str=iface_str)
+        test_str = self._test_gen.str_to_file(request, test_path)
         if compilation_error := try_compile_file(test_path):
             attempt = test_generator.GenerationAttempt(code=test_str, errors=compilation_error)
-            test_str = self._test_gen.str_to_file(iface_str, test_path, [attempt])
+            request = test_generator.TestGenerationRequest(interface_str=iface_str, prior_attempts=[attempt])
+            test_str = self._test_gen.str_to_file(request, test_path)
 
     def impl_iteration_loop(self, iface_path: str, test_path: str) -> None:
         """Iterates on impl creation, returning the finished file."""


### PR DESCRIPTION
# Jules refactoring

This commit refactors the TestGenerator class and its usages to use a TestGenerationRequest dataclass for its requests, similar to how ImplGenerator uses ImplGenerationRequest.

The following changes were made:
- Created a  dataclass in .
- Refactored the  and  methods to accept a  object instead of individual parameters.
- Updated the  to use
- Updated ,  and the main function in  to use .
- Fixed .