### PR TITLE
Refactor: Replace dataclasses with Pydantic models

### DIFF
--- a/agents/impl_generator.py
+++ b/agents/impl_generator.py
@@ -3,21 +3,10 @@ from pydantic_ai import Agent
 from dotenv import load_dotenv
 import textwrap
 from . import utils
-import dataclasses
+from .models import GenerationAttempt, ImplGenerationRequest # Import Pydantic models
 
-
-@dataclasses.dataclass(frozen=True)
-class GenerationAttempt:
-    code: str
-    errors: str
-
-
-@dataclasses.dataclass(frozen=True)
-class ImplGenerationRequest:
-    interface_str: str
-    test_str: str
-    prior_attempts: list[GenerationAttempt] = dataclasses.field(default_factory=list)
-
+# Removed dataclass definitions for GenerationAttempt and ImplGenerationRequest
+# Removed import dataclasses
 
 class ImplGenerator:
 

--- a/agents/models.py
+++ b/agents/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+from typing import List
+
+class GenerationAttempt(BaseModel):
+    code: str
+    errors: str
+
+class ImplGenerationRequest(BaseModel):
+    interface_str: str
+    test_str: str
+    prior_attempts: List[GenerationAttempt] = Field(default_factory=list)
+
+class TestGenerationRequest(BaseModel):
+    interface_str: str
+    prior_attempts: List[GenerationAttempt] = Field(default_factory=list)

--- a/agents/test_generator.py
+++ b/agents/test_generator.py
@@ -3,20 +3,10 @@ from pydantic_ai import Agent
 from dotenv import load_dotenv
 import textwrap
 from . import utils
-from dataclasses import dataclass, field
+from .models import GenerationAttempt, TestGenerationRequest # Import Pydantic models
 
-
-@dataclass(frozen=True)
-class GenerationAttempt:
-    code: str
-    errors: str
-
-
-@dataclass(frozen=True)
-class TestGenerationRequest:
-    interface_str: str
-    prior_attempts: list[GenerationAttempt] = field(default_factory=list)
-
+# Removed dataclass definitions for GenerationAttempt and TestGenerationRequest
+# Removed import for dataclasses
 
 class TestGenerator:
 

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,6 @@
 from agents import impl_generator
 from agents import test_generator
-from dataclasses import dataclass
+from pydantic import BaseModel # Import BaseModel for Pydantic
 from dotenv import load_dotenv
 import os
 import py_compile
@@ -10,12 +10,13 @@ import unittest
 import logfire
 
 
-@dataclass
-class Example:
+# Define the Pydantic model Example
+class Example(BaseModel):
     code: str
     project_name: str
     filename: str
 
+# Removed old dataclass Example definition
 
 math_utils = Example(
     project_name='math-utils',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 modelcontextprotocol
 uvicorn[standard]
 fastapi
+pydantic


### PR DESCRIPTION
I've converted all identified Python dataclasses to Pydantic models to leverage Pydantic's data validation and serialization features.

Here's what I did:
- I created `agents/models.py` to house shared Pydantic models (`GenerationAttempt`, `ImplGenerationRequest`, `TestGenerationRequest`).
- I updated `agents/impl_generator.py` and `agents/test_generator.py` to use these new models.
- I converted the `Example` dataclass in `demo.py` to a Pydantic model.
- I ensured `pydantic` and `pydantic-ai` are listed in `requirements.txt`.
- I installed dependencies and ran tests.

The tests in `utils_test.py` pass. However, I couldn't fully test `demo.py` as it requires an OpenAI API key, which was not available in the execution environment.