### PR TITLE
Add tests and fix bugs in utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 import re
 
-_CLASS_FINDER = re.compile(r'^\s*class\s+([A-Z][a-zA-Z0-9_]*)(?:\s*\([^)]*\))?\s*:')
+_CLASS_FINDER = re.compile(r'^\s*class\s+([A-Z][a-zA-Z0-9_]*)')
 
 
 def guess_classname(code: str) -> str:

--- a/utils_test.py
+++ b/utils_test.py
@@ -81,3 +81,25 @@ class UtilsTest(unittest.TestCase):
     def test_camel_to_snake_complex_numbers(self):
         self.assertEqual(camel_to_snake("A1B2C3"), "a1_b2_c3")
         self.assertEqual(camel_to_snake("v6Address"), "v6_address")
+
+    def test_guess_classname_with_decorator(self):
+        code = "@decorator\nclass MyClass: pass"
+        self.assertEqual(guess_classname(code), "MyClass")
+
+    def test_guess_classname_indented(self):
+        code = "    class MyClass: pass"
+        self.assertEqual(guess_classname(code), "MyClass")
+
+    def test_guess_classname_multiline(self):
+        code = "class MyClass(\n    ABC\n): pass"
+        self.assertEqual(guess_classname(code), "MyClass")
+
+    def test_camel_to_snake_with_trailing_capitals(self):
+        self.assertEqual(camel_to_snake("MyHTTP"), "my_http")
+
+    def test_camel_to_snake_consecutive_capitals(self):
+        self.assertEqual(camel_to_snake("JSONParser"), "json_parser")
+        self.assertEqual(camel_to_snake("SimpleJSONParser"), "simple_json_parser")
+
+    def test_camel_to_snake_alphanumeric(self):
+        self.assertEqual(camel_to_snake("ABC123Def"), "abc123_def")


### PR DESCRIPTION
This PR adds comprehensive test cases to `utils_test.py` for both `guess_classname` and `camel_to_snake` utilities. It also fixes a bug in `guess_classname` where it failed to identify class names in multiline class definitions by simplifying the matching regex.

---
*PR created automatically by Jules for task [12273838448116521436](https://jules.google.com/task/12273838448116521436) started by @digitalex*